### PR TITLE
Remove unused evidence vars and add typed API bodies

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,15 +1,24 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Anthropic from '@anthropic-ai/sdk';
 import { PrismaClient } from '@prisma/client';
+import { GameState, Suspect } from '@/types/game';
 
 const prisma = new PrismaClient();
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,
 });
 
+interface ChatRequestBody {
+  suspectId: string;
+  question: string;
+  gameState: GameState & { suspectsData?: Record<string, Suspect> };
+  caseId: string;
+}
+
 export async function POST(request: NextRequest) {
   try {
-    const { suspectId, question, gameState, caseId } = await request.json();
+    const { suspectId, question, gameState, caseId } =
+      await request.json() as ChatRequestBody;
     
     console.log('💬 CHAT REQUEST:');
     console.log('- Case:', caseId);

--- a/src/app/api/evidence/generate/route.ts
+++ b/src/app/api/evidence/generate/route.ts
@@ -1,24 +1,30 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Anthropic from '@anthropic-ai/sdk';
 import { PrismaClient } from '@prisma/client';
+import { Evidence } from '@/types/game';
 
 const prisma = new PrismaClient();
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,
 });
 
+interface EvidenceGenerationRequest {
+  characterResponse: string;
+  characterName: string;
+  existingEvidence: Evidence[];
+  evidenceCount: number;
+  caseId: string;
+}
+
 export async function POST(request: NextRequest) {
   try {
-    const { 
-      playerQuestion, 
-      characterResponse, 
+    const {
+      characterResponse,
       characterName,
-      existingEvidence, 
-      conversationHistory,
-      actionsRemaining,
+      existingEvidence,
       evidenceCount,
       caseId
-    } = await request.json();
+    } = await request.json() as EvidenceGenerationRequest;
 
     console.log('🧩 EVIDENCE GENERATION REQUEST:');
     console.log('- Case:', caseId);
@@ -54,7 +60,7 @@ export async function POST(request: NextRequest) {
     const existingEmojis = new Set();
     const existingNames = new Set();
     
-    const existingEvidenceList = existingEvidence.map((e: any) => {
+    const existingEvidenceList = existingEvidence.map((e: Evidence) => {
       // Track by emoji
       existingEmojis.add(e.emoji);
       

--- a/src/app/api/evidence/validate/route.ts
+++ b/src/app/api/evidence/validate/route.ts
@@ -1,24 +1,30 @@
 // src/app/api/evidence/validate/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 import Anthropic from '@anthropic-ai/sdk';
+import { Evidence } from '@/types/game';
 
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,
 });
 
+interface EvidenceValidationRequest {
+  proposedEvidence: Evidence;
+  existingEvidence: Evidence[];
+}
+
 export async function POST(request: NextRequest) {
   try {
-    const { 
+    const {
       proposedEvidence,
       existingEvidence
-    } = await request.json();
+    } = await request.json() as EvidenceValidationRequest;
 
     console.log('🔍 EVIDENCE UNIQUENESS CHECK:');
     console.log('- Proposed:', proposedEvidence);
     console.log('- Existing Count:', existingEvidence.length);
 
     // Build existing evidence context
-    const existingEvidenceList = existingEvidence.map((e: any) => 
+    const existingEvidenceList = existingEvidence.map((e: Evidence) =>
       `${e.emoji} ${e.name}: ${e.description}`
     ).join('\n');
 
@@ -47,7 +53,7 @@ Consider these as DIFFERENT (should accept):
 
 CRITICAL: Also check if the EMOJI is already used. Each piece of evidence must have a unique emoji.
 
-Existing emojis: ${existingEvidence.map((e: any) => e.emoji).join(', ') || 'None'}
+Existing emojis: ${existingEvidence.map((e: Evidence) => e.emoji).join(', ') || 'None'}
 
 Respond with ONLY valid JSON:
 {

--- a/src/app/api/inspect/route.ts
+++ b/src/app/api/inspect/route.ts
@@ -1,15 +1,23 @@
 import { NextRequest, NextResponse } from 'next/server';
 import Anthropic from '@anthropic-ai/sdk';
 import { PrismaClient } from '@prisma/client';
+import { GameState } from '@/types/game';
 
 const prisma = new PrismaClient();
 const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY,
 });
 
+interface InspectRequestBody {
+  inspection: string;
+  gameState: GameState;
+  caseId: string;
+}
+
 export async function POST(request: NextRequest) {
   try {
-    const { inspection, gameState, caseId } = await request.json();
+    const { inspection, gameState, caseId } =
+      await request.json() as InspectRequestBody;
 
     console.log('🔍 INSPECT REQUEST:');
     console.log('- Case:', caseId);


### PR DESCRIPTION
## Summary
- clean up unused variables in evidence generation API
- introduce request body interfaces for chat, inspect, and evidence validation APIs
- specify Evidence type in evidence handling

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_687a851d019c8329a4b200f5fe5d8535