### PR TITLE
Add case file emoji next to title

### DIFF
--- a/src/components/game/GameInterface.tsx
+++ b/src/components/game/GameInterface.tsx
@@ -326,7 +326,7 @@ export default function GameInterface({ caseId, onCaseChange }: GameInterfacePro
         >
           {isCaseCollapsed ? '▼' : '▲'}
         </button>
-        <h2 className="case-title">{currentCase.title}</h2>
+        <h2 className="case-title">🗂️ {currentCase.title}</h2>
         <div className="case-description">
           {currentCase.description}
         </div>

--- a/src/components/game/LandingPage.tsx
+++ b/src/components/game/LandingPage.tsx
@@ -75,7 +75,7 @@ export default function LandingPage({ onStartGame }: LandingPageProps) {
       <h1 className="game-title">Case of the Week</h1>
       
       <div className="case-file">
-        <h2 className="case-title">{selectedCase.title}</h2>
+        <h2 className="case-title">🗂️ {selectedCase.title}</h2>
         <div className="case-description">
           {selectedCase.description}
         </div>


### PR DESCRIPTION
## Summary
- add case file emoji to `LandingPage` title
- add case file emoji to case header in `GameInterface`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac37bb09483278dcff06fd8ae3948